### PR TITLE
Improve public API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Zonemaster-*.tar.gz
 # Backup files from editor, by unknown and Emacs, respectively
 *.bak
 *~
+.*.swp
 
 # Unknown
 dev.pl

--- a/lib/Zonemaster/Engine/Recursor.pm
+++ b/lib/Zonemaster/Engine/Recursor.pm
@@ -65,20 +65,20 @@ sub get_fake_addresses {
 }
 
 sub recurse {
-    my ( $self, $name, $type, $class ) = @_;
+    my ( $self, $name, $type, $dns_class ) = @_;
     $name = name( $name );
-    $type  //= 'A';
-    $class //= 'IN';
+    $type      //= 'A';
+    $dns_class //= 'IN';
 
-    Zonemaster::Engine->logger->add( RECURSE => { name => $name, type => $type, class => $class } );
-    if ( exists $recurse_cache{$name}{$type}{$class} ) {
-        return $recurse_cache{$name}{$type}{$class};
+    Zonemaster::Engine->logger->add( RECURSE => { name => $name, type => $type, class => $dns_class } );
+    if ( exists $recurse_cache{$name}{$type}{$dns_class} ) {
+        return $recurse_cache{$name}{$type}{$dns_class};
     }
 
     my ( $p, $state ) =
-      $self->_recurse( $name, $type, $class,
+      $self->_recurse( $name, $type, $dns_class,
         { ns => [ root_servers() ], count => 0, common => 0, seen => {}, glue => {} } );
-    $recurse_cache{$name}{$type}{$class} = $p;
+    $recurse_cache{$name}{$type}{$dns_class} = $p;
 
     return $p;
 }
@@ -132,7 +132,7 @@ sub parent {
 } ## end sub parent
 
 sub _recurse {
-    my ( $self, $name, $type, $class, $state ) = @_;
+    my ( $self, $name, $type, $dns_class, $state ) = @_;
     $name = q{} . name( $name );
 
     if ( $state->{in_progress}{$name}{$type} ) {
@@ -150,10 +150,10 @@ sub _recurse {
                 address => $nsaddress,
                 name    => $name,
                 type    => $type,
-                class   => $class
+                class   => $dns_class,
             }
         );
-        my $p = $self->_do_query( $ns, $name, $type, { class => $class }, $state );
+        my $p = $self->_do_query( $ns, $name, $type, { class => $dns_class }, $state );
 
         next if not $p;    # Ask next server if no response
 
@@ -344,8 +344,8 @@ Zonemaster::Engine::Recursor - recursive resolver for Zonemaster
 
 =head1 SYNOPSIS
 
-    my $packet = Zonemaster::Engine::Recursor->recurse($name, $type, $class);
-    my $pname = Zonemaster::Engine::Recursor->parent('example.org');
+    my $packet = Zonemaster::Engine::Recursor->recurse( $name, $type, $dns_class );
+    my $pname  = Zonemaster::Engine::Recursor->parent( 'example.org' );
 
 =head1 CLASS VARIABLES
 

--- a/lib/Zonemaster/Engine/Recursor.pm
+++ b/lib/Zonemaster/Engine/Recursor.pm
@@ -20,18 +20,9 @@ our %recurse_cache;
 our %_fake_addresses_cache;
 
 {
-    my $path = get_default_path();
+    my $path = dist_file( 'Zonemaster-Engine', 'root-hints.json' );
     my $json = read_file $path;
     $seed_data = decode_json $json;
-}
-
-sub get_default_path {
-    state $path =
-        length( $ENV{ZONEMASTER_ENGINE_ROOT_HINTS_FILE} )    ? $ENV{ZONEMASTER_ENGINE_ROOT_HINTS_FILE}
-      : -e '/etc/zonemaster/root-hints.json'                 ? '/etc/zonemaster/root-hints.json'
-      : -e '/usr/local/etc/zonemaster/root-hints.json'       ? '/usr/local/etc/zonemaster/root-hints.json'
-      :                                                        eval { dist_file( 'Zonemaster-Engine', 'root-hints.json' ) };
-    return $path // croak "File not found: root-hints.json\n";
 }
 
 sub add_fake_addresses {
@@ -374,39 +365,6 @@ The IP addresses are those of the nameservers which are used in case of fake
 delegations (pre-publication tests).
 
 =head1 METHODS
-
-=head2 get_default_path
-
-Determine the path for the default root-hints.json file.
-A list of values and locations are checked and the first match is returned.
-If all places are checked and no file is found, an exception is thrown.
-
-This procedure is idempotent - i.e. if you call this procedure multiple times
-the same value is returned no matter if environment variables or the file system
-have changed.
-
-The following checks are made in order:
-
-=over 4
-
-=item $ZONEMASTER_ENGINE_ROOT_HINTS_FILE
-
-If this environment variable is set to a non-empty string, that path is returned.
-
-=item /etc/zonemaster/root-hints.json
-
-If a file exists at this path, it is returned.
-
-=item /usr/local/etc/zonemaster/root-hints.json
-
-If a file exists at this path, it is returned.
-
-=item DIST_DIR/root-hints.json
-
-If a file exists at this path, it is returned.
-DIST_DIR is wherever File::ShareDir installs the Zonemaster-Engine dist.
-
-=back
 
 =head2 recurse($name, $type, $class)
 

--- a/lib/Zonemaster/Engine/Recursor.pm
+++ b/lib/Zonemaster/Engine/Recursor.pm
@@ -19,6 +19,11 @@ my $seed_data;
 our %recurse_cache;
 our %_fake_addresses_cache;
 
+{
+    my $path = get_default_path();
+    my $json = read_file $path;
+    $seed_data = decode_json $json;
+}
 
 sub get_default_path {
     state $path =
@@ -336,15 +341,6 @@ sub clear_cache {
 }
 
 sub root_servers {
-    my $path = get_default_path();
-    my $json = read_file $path;
-    {
-        local $/;
-        $seed_data = decode_json $json;
-    }
-
-    return croak "File not valid: $path\n" unless $seed_data;
-
     return map { Zonemaster::Engine::Util::ns( $_->{name}, $_->{address} ) }
       sort { $a->{name} cmp $b->{name} } @{ $seed_data->{'.'} };
 }

--- a/lib/Zonemaster/Engine/Recursor.pm
+++ b/lib/Zonemaster/Engine/Recursor.pm
@@ -27,27 +27,11 @@ our %_fake_addresses_cache;
         for my $ns ( @{ $seed_data->{$domain} } ) {
             push @{ $fake_data{ $ns->{name} } }, $ns->{address};
         }
-        Zonemaster::Engine::Recursor->_add_fake_addresses( $domain, \%fake_data );
+        Zonemaster::Engine::Recursor->add_fake_addresses( $domain, \%fake_data );
     }
 }
 
 sub add_fake_addresses {
-    my ( $class, $domain, $href ) = @_;
-
-    # Fake addresses for the root zone used to be implicitly ignored. To
-    # preserve this behavior after a refactoring we need to ignore it
-    # explicitly. This is done purely for the sake of correcness, not because it
-    # is a meaningful behavior.
-    if ( $domain eq '.' ) {
-        return;
-    }
-
-    _add_fake_addresses( $domain, $href );
-
-    return;
-}
-
-sub _add_fake_addresses {
     my ( $class, $domain, $href ) = @_;
     $domain = lc $domain;
 
@@ -84,6 +68,15 @@ sub get_fake_addresses {
     else {
         return ();
     }
+}
+
+sub remove_fake_addresses {
+    my ( $class, $domain ) = @_;
+    $domain = lc $domain;
+
+    delete $_fake_addresses_cache{$domain};
+
+    return;
 }
 
 sub recurse {
@@ -429,13 +422,34 @@ Check if there is at least one fake nameserver specified for the given domain.
 Returns a list of all cached fake addresses for the given domain and name server name.
 Returns an empty list if no data is cached for the given arguments.
 
+=item remove_fake_addresses($domain)
+
+Remove fake delegation data for a specified domain.
+
 =head2 clear_cache()
 
 Class method to empty the cache of responses to recursive queries (but not the ones for fake delegations).
 
+N.B. This method does not affect fake delegation data.
+
 =head2 root_servers()
 
-Returns a list of ns objects representing the root servers. The list of root servers is found in an external
-file.
+Returns a list of ns objects representing the root servers.
+
+    my @name_servers = Zonemaster::Engine::Recursor->root_servers();
+
+The default list of root servers is read from a file installed in the shared data directory.
+This list can be replaced like so:
+
+    Zonemaster::Engine::Recursor->remove_fake_addresses( '.' );
+    Zonemaster::Engine::Recursor->add_fake_addresses(
+        '.',
+        {
+            'ns1.example' => ['192.0.2.1'],
+            'ns2.example' => ['192.0.2.2'],
+        }
+    );
+
+=back
 
 =cut


### PR DESCRIPTION
## Purpose

The purpose of this PR is to change the API of the root hints customization feature in a number of ways:
1. Make its API more programmatic by providing a native Perl API.
2. Make it more transparent by not having library code accept arguments thorugh environment variables.
3. Avoid exposing the custom JSON hints formats in the publc API. A better choice for format would be the zone file format used by IANA in the hints file they publish. Dropping support for the JSON format in the public API would be a breaking change, so it's better to not expose it there in the first place.

## Context

This PR is made as an extension to to zonemaster/zonemaster-engine#1132.

## Changes

* Allow callers to remove fake delegation for the `.` domain and add their own root hints instead.
  * Make Zonemaster::Engine::Recursor look up the root hints from its fake delegation data.
  * Extend the fake delegation API in Zonemaster::Engine::Recursor to allow removing fake delegation data from a given domain.
* Make Engine only read the hints JSON file from its own installation directory.

Somewhat unrelatedly, this PR also clarifies the Zonemaster::Engine:Recursor module with regard to class methods, and it makes git ignore vim swap files.

## How to test this PR
Make sure to begin each of the following test cases from a clean state.

It would be super nice to have an automatic test for the first one of these. However that is out of scope for this PR. All the other involves technically breaking the installation, and it doesn't really make sense to have unit tests for when the installation is broken.

### Overriding the root hints programmatically
1. Set up a name server with a custom root zone
2. Modify Zonemaster::CLI to use the example provided under root_servers in `perldoc Zonemaster::Engine::Recursor` (but with the IP addresses of your own name server).
3. Start tcpdump and watch for any traffic to the IANA root name servers. (There shouldn't be any.)
4. Run zonemaster-cli on a zone under your custom root.

### Overriding the root hints by editing the installation
1. Set up a name server with a custom root zone
2. Modify root-hints.json to use your custom root name server.
3. Start tcpdump and watch for any traffic to the IANA root name servers. (There shouldn't be any.)
4. Run zonemaster-cli on a zone under your custom root.

### An exception is thrown when the  root hints file contains syntax errors
1. Add garbage characters to the root hints file.
2. Run zonemaster-cli zonemaster.net
3. Make sure it aborts with an error message about a missing root hints file. (This means the installation is broken so the error message doesn't have to be super friendly.)

### An exception is thrown when the  root hints file is missing
1. Remove the root hints file.
2. Run zonemaster-cli zonemaster.net
3. Make sure it aborts with an error message about a missing root hints file. (This means the installation is broken so the error message doesn't have to be super friendly.)

